### PR TITLE
Fix for tilesets not defining pixelscale.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -352,7 +352,7 @@ export type ContainerSlot = {
   seals?: boolean; // default: false
   watertight?: boolean; // default: false
   preserves?: boolean; // default: false
-  unseals_into?: boolean; // item_id
+  unseals_into?: string; // item_id
 };
 
 export type ComestibleSlot = {
@@ -1310,7 +1310,7 @@ export type Monster = {
         age_grow?: integer;
         into_group?: string;
         into?: string;
-		multiple_spawns?: boolean;
+        multiple_spawns?: boolean;
         spawn_range?: integer;
       };
   ascii_picture?: string;
@@ -1509,7 +1509,7 @@ export type BodyPart = {
   side: "left" | "right" | "both";
 
   sub_parts?: string[]; // sub_body_part_id
-  
+
   encumbrance_per_weight?: {
     weight: string;
     encumbrance: integer;

--- a/src/types/Item.svelte
+++ b/src/types/Item.svelte
@@ -211,7 +211,7 @@ const grantedByMutation = data
   .filter((m) => m.id && m.integrated_armor?.some((x) => x === item.id));
 
 function normalizeStackVolume(item: Item): (string | number) | undefined {
-  if (item.type === "AMMO" && item.ammunition_type!== "components") {
+  if (item.type === "AMMO" && item.ammo_type !== "components") {
     const { count } = item;
     return `${parseVolume(item.volume ?? "1 ml") / (count ?? 1)} ml`;
   }

--- a/src/types/item/ItemSymbol.svelte
+++ b/src/types/item/ItemSymbol.svelte
@@ -15,6 +15,9 @@ export let item: {
 let data: CddaData = getContext("data");
 
 $: tile_info = $tileData?.tile_info[0];
+$: if (tile_info) {
+  tile_info.pixelscale = tile_info.pixelscale ?? 1;
+}
 $: tile = typeHasTile(item)
   ? findTileOrLooksLike($tileData, item) ??
     fallbackTile($tileData, item.symbol, item.color ?? "white")


### PR DESCRIPTION
Namely MSX++UndeadPeopleEdition. Which leads to visual misalignment of sprites.
Setting default to 1 fixes the issue.

Before
![Before](https://github.com/user-attachments/assets/f5d8473c-89b5-4e81-8148-0751c2c1179f)

After
![After](https://github.com/user-attachments/assets/4f41e6f7-8661-4db9-aa84-8b917b8a1fa7)
