### PR TITLE
Fixed tileset issue when pixelscale is undefined

### DIFF
--- a/src/tile-data.ts
+++ b/src/tile-data.ts
@@ -31,6 +31,8 @@ const fetchJson = async (url: string) => {
       chunk.ny = ny;
     })
   );
+  //Some tilesets doesn't have pixelscale defined
+  json["tile_info"][0].pixelscale = json["tile_info"][0].pixelscale ?? 1
   return json;
 };
 


### PR DESCRIPTION
Some tilesets, like MSX++UndeadPeopleEdition, do not define pixelscale, causing sprite misalignment.
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/db25afa3-16bf-4cfb-9192-5f0635820466) | ![image](https://github.com/user-attachments/assets/23476f2c-4b73-4afd-b7a3-63ba594eb288) | 

svelte-check throws errors, but it's unrelated to this PR 